### PR TITLE
fix: nil route panic, silent no-op without labels, narrow stat error …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+make build      # compile to ./build/routest (with version ldflags)
+make test       # go test -v ./...
+make testcov    # coverage report → coverage.out
+make vet        # go vet ./...
+make lint       # golangci-lint run -v --timeout=15m ./...
+make install    # copy binary to ~/.local/bin
+make clean      # remove build artifacts
+```
+
+## Architecture
+
+`routest` is a single-binary CLI that tests Alertmanager routing configurations — given a set of labels, it reports which receiver(s) an alert would be routed to.
+
+**Entry point:** `cmd/routest/main.go`
+- Parses `-file`, `-labels`, and `-version` flags
+- Reads Alertmanager YAML config from a file or stdin
+- Unmarshals config using `gopkg.in/yaml.v3` into `github.com/prometheus/alertmanager/config.Config`
+- Builds a route dispatch tree via `dispatch.NewRoute(c.Route, nil)`
+- Calls `.Match(labelSet)` to find matching routes and prints their receivers
+
+**Build info:** `internal/buildinfo/buildinfo.go` — `Version`, `Name`, and `GitSHA` are injected via ldflags at build time (see `Makefile` `LDFLAGS`).
+
+The Alertmanager `dispatch` package handles route tree traversal including `continue` semantics; `Match()` returns all routes the alert should be delivered to.

--- a/cmd/routest/main.go
+++ b/cmd/routest/main.go
@@ -58,6 +58,11 @@ func main() {
 		labelSets["custom"] = labelSet
 	}
 
+	if len(labelSets) == 0 {
+		slog.Error("no labels provided, use -labels flag")
+		os.Exit(1)
+	}
+
 	var alertmanagerConfig string
 
 	if routestOpts.configFile == "" {
@@ -81,7 +86,7 @@ func main() {
 	} else {
 		slog.Info("Reading config file", "path", routestOpts.configFile)
 
-		if _, err := os.Stat(routestOpts.configFile); os.IsNotExist(err) || os.IsPermission(err) {
+		if _, err := os.Stat(routestOpts.configFile); err != nil {
 			slog.Error("config file does not exist or is not accessible", "path", routestOpts.configFile, "error", err)
 			os.Exit(1)
 		}
@@ -106,6 +111,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if c.Route == nil {
+		slog.Error("alertmanager config is missing a route definition")
+		os.Exit(1)
+	}
+
 	for _, labelSet := range labelSets {
 		slog.Info("Testing with labels", "labels", labelSet)
 
@@ -120,9 +130,7 @@ func main() {
 		var results []string
 		for _, route := range routes {
 			results = append(results, route.RouteOpts.Receiver)
-			if route.Continue {
-				continue
-			} else {
+			if !route.Continue {
 				break
 			}
 		}


### PR DESCRIPTION
…check, dead continue

- Panic if c.Route is nil (missing route: key in config) instead of passing nil to dispatch.NewRoute
- Exit with error when no -labels flag is provided instead of silently doing nothing
- Broaden os.Stat error check from IsNotExist||IsPermission to err != nil
- Replace dead continue/else-break pattern with simpler if !route.Continue { break }
- Add CLAUDE.md with build commands and architecture overview

Assisted-by: claude-code/claude-sonnet-4-6